### PR TITLE
Fixed incomplete function name in computeRMS

### DIFF
--- a/+ERAASR/computeRMS.m
+++ b/+ERAASR/computeRMS.m
@@ -12,7 +12,7 @@ function rms = computeRMS(data, varargin)
     p.parse(varargin{:});
 
     if ~isempty(p.Results.clip)
-        data = TensorUtils.clip(data, p.Results.clip, NaN);
+        data = ERAASR.TensorUtils.clip(data, p.Results.clip, NaN);
     end
 
     if iscell(data)


### PR DESCRIPTION
Hi Dan,

While trying to run the example, the `computeRMS` function failed because the call to `TensorUtils.clip` on line 15 did not fully specify the function name as `ERAASR.TensorUtils.clip`. This simple edit allows the example to run successfully.

Thanks for open-sourcing this project!